### PR TITLE
[TEST RUN - do not merge] Unify history item deletion prompts

### DIFF
--- a/Trio/Sources/Localizations/Main/Localizable.xcstrings
+++ b/Trio/Sources/Localizations/Main/Localizable.xcstrings
@@ -124604,6 +124604,7 @@
     },
     "Error" : {
       "comment" : "Error title",
+      "extractionState" : "stale",
       "localizations" : {
         "bg" : {
           "stringUnit" : {
@@ -130507,9 +130508,6 @@
           }
         }
       }
-    },
-    "Failed to delete glucose data: %@" : {
-      "comment" : "Error alert shown when glucose deletion from CoreData fails — interpolated value is a localized error description from the OS"
     },
     "Failed to execute a batch delete request in %@ from %@." : {
       "localizations" : {

--- a/Trio/Sources/Modules/History/HistoryDeletionTarget.swift
+++ b/Trio/Sources/Modules/History/HistoryDeletionTarget.swift
@@ -2,6 +2,10 @@ import CoreData
 import Foundation
 
 extension History {
+    /// Single source of truth for what a History row delete swipe is about to remove.
+    /// Replaces three separate `.alert` modifiers (glucose, insulin, carbs — the meals
+    /// tab and the combined treatments tab both route carb deletion through the same
+    /// `.carbs` case) that used to share state and could misfire across each other.
     enum DeletionTarget: Identifiable {
         case glucose(GlucoseStored)
         case insulin(PumpEventStored)
@@ -22,7 +26,7 @@ extension History {
             case .insulin:
                 return String(localized: "Delete Insulin?", comment: "Alert title for deleting insulin")
             case let .carbs(carbEntry):
-                if carbEntry.fpuID == nil {
+                guard carbEntry.fpuID != nil else {
                     return String(localized: "Delete Carbs?", comment: "Alert title for deleting carbs")
                 }
                 return carbEntry.isFPU
@@ -31,7 +35,7 @@ extension History {
             }
         }
 
-        func message(units: GlucoseUnits) -> String? {
+        func message(units: GlucoseUnits) -> String {
             switch self {
             case let .glucose(glucose):
                 let glucoseToDisplay = units == .mgdL
@@ -49,7 +53,7 @@ extension History {
                 }
                 return text
             case let .carbs(carbEntry):
-                if carbEntry.fpuID == nil {
+                guard carbEntry.fpuID != nil else {
                     return Formatter.dateFormatter.string(from: carbEntry.date ?? Date())
                         + ", "
                         + (Formatter.decimalFormatterWithTwoFractionDigits.string(for: carbEntry.carbs) ?? "0")
@@ -60,6 +64,12 @@ extension History {
                     comment: "Alert message for meal deletion"
                 )
             }
+        }
+
+        /// True for a meal that will cascade-delete FPU rows on top of its own carbs.
+        var isFpuOrComplexMeal: Bool {
+            guard case let .carbs(carbEntry) = self else { return false }
+            return carbEntry.isFPU || carbEntry.fat > 0 || carbEntry.protein > 0
         }
     }
 }

--- a/Trio/Sources/Modules/History/View/HistoryRootView.swift
+++ b/Trio/Sources/Modules/History/View/HistoryRootView.swift
@@ -7,14 +7,7 @@ extension History {
         let resolver: Resolver
 
         @State var state = StateModel()
-        @State private var isRemoveHistoryItemAlertPresented: Bool = false
-        @State private var isRemoveMealAlertPresented: Bool = false // Add this new one
-        @State private var alertTitle: String = ""
-        @State private var alertMessage: String = ""
-        @State private var alertTreatmentToDelete: PumpEventStored?
-        @State private var alertCarbEntryToDelete: CarbEntryStored?
-        @State private var alertGlucoseToDelete: GlucoseStored?
-        @State private var showAlert = false
+        @State private var deletionTarget: History.DeletionTarget?
         @State private var showFutureEntries: Bool = false
         @State private var showManualGlucose: Bool = false
         @State private var isAmountUnconfirmed: Bool = true
@@ -287,6 +280,31 @@ extension History {
                         CarbEntryEditorView(state: state, carbEntry: carbEntry)
                     }
                 }
+                .glassActionSheet(
+                    Text(deletionTarget?.title(units: state.units) ?? ""),
+                    message: deletionTarget.map { Text($0.message(units: state.units)) },
+                    isPresented: Binding(
+                        get: { deletionTarget != nil },
+                        set: { if !$0 { deletionTarget = nil } }
+                    ),
+                    actions: [
+                        GlassSheetAction("Delete", role: .destructive) {
+                            switch deletionTarget {
+                            case let .glucose(glucose):
+                                state.invokeGlucoseDeletionTask(glucose.objectID)
+                            case let .insulin(pumpEvent):
+                                state.invokeInsulinDeletionTask(pumpEvent.objectID)
+                            case let .carbs(carbEntry):
+                                state.invokeCarbDeletionTask(
+                                    carbEntry.objectID,
+                                    isFpuOrComplexMeal: deletionTarget?.isFpuOrComplexMeal ?? false
+                                )
+                            case .none:
+                                break
+                            }
+                        }
+                    ]
+                )
         }
 
         @ViewBuilder func addButton(_ action: @escaping () -> Void) -> some View {
@@ -818,33 +836,8 @@ extension History {
                                 "Delete",
                                 systemImage: "trash.fill",
                                 role: .none,
-                                action: {
-                                    alertGlucoseToDelete = glucose
-                                    let glucoseToDisplay = state.units == .mgdL ? glucose.glucose
-                                        .description : Int(glucose.glucose).formattedAsMmolL
-                                    alertTitle = String(localized: "Delete Glucose?", comment: "Alert title for deleting glucose")
-                                    alertMessage = Formatter.dateFormatter
-                                        .string(from: glucose.date ?? Date()) + ", " + glucoseToDisplay + " " + state.units
-                                        .rawValue
-                                    isRemoveHistoryItemAlertPresented = true
-                                }
+                                action: { deletionTarget = .glucose(glucose) }
                             ).tint(.red)
-                        }
-                        .alert(
-                            Text(alertTitle),
-                            isPresented: $isRemoveHistoryItemAlertPresented
-                        ) {
-                            Button("Cancel", role: .cancel) {}
-                            Button("Delete", role: .destructive) {
-                                guard let glucoseToDelete = alertGlucoseToDelete else {
-                                    debug(.default, "Cannot gracefully unwrap alertCarbEntryToDelete!")
-                                    return
-                                }
-                                let glucoseToDeleteObjectID = glucoseToDelete.objectID
-                                state.invokeGlucoseDeletionTask(glucoseToDeleteObjectID)
-                            }
-                        } message: {
-                            Text("\n" + alertMessage)
                         }
                     }
                 } else {
@@ -854,30 +847,6 @@ extension History {
                     )
                 }
             }.listRowBackground(Color.chart)
-                .alert(isPresented: $showAlert) {
-                    Alert(title: Text("Error"), message: Text(alertMessage), dismissButton: .default(Text("OK")))
-                }
-        }
-
-        private func deleteGlucose(at offsets: IndexSet) {
-            for index in offsets {
-                let glucoseToDelete = glucoseStored[index]
-                context.delete(glucoseToDelete)
-            }
-
-            do {
-                try context.save()
-                debugPrint("Data Table Root View: \(#function) \(DebuggingIdentifiers.succeeded) deleted glucose from core data")
-            } catch {
-                debugPrint(
-                    "Data Table Root View: \(#function) \(DebuggingIdentifiers.failed) error while deleting glucose from core data"
-                )
-                alertMessage = String(
-                    localized: "Failed to delete glucose data: \(error.localizedDescription)",
-                    comment: "Error alert shown when glucose deletion from CoreData fails — interpolated value is a localized error description from the OS"
-                )
-                showAlert = true
-            }
         }
 
         @ViewBuilder private func addGlucoseView() -> some View {
@@ -1037,40 +1006,9 @@ extension History {
                         "Delete",
                         systemImage: "trash.fill",
                         role: .none,
-                        action: {
-                            alertTreatmentToDelete = item
-                            alertTitle = String(localized: "Delete Insulin?", comment: "Alert title for deleting insulin")
-                            alertMessage = Formatter.dateFormatter
-                                .string(from: item.timestamp ?? Date()) + ", " +
-                                (Formatter.decimalFormatterWithThreeFractionDigits.string(from: item.bolus?.amount ?? 0) ?? "0") +
-                                String(localized: " U", comment: "Insulin unit")
-                            if let bolus = item.bolus {
-                                alertMessage += bolus.isSMB ? String(
-                                    localized: " SMB",
-                                    comment: "Super Micro Bolus indicator in delete alert"
-                                )
-                                    : ""
-                            }
-                            isRemoveHistoryItemAlertPresented = true
-                        }
+                        action: { deletionTarget = .insulin(item) }
                     ).tint(.red)
                 }
-            }
-            .alert(
-                Text(alertTitle),
-                isPresented: $isRemoveHistoryItemAlertPresented
-            ) {
-                Button("Cancel", role: .cancel) {}
-                Button("Delete", role: .destructive) {
-                    guard let treatmentToDelete = alertTreatmentToDelete else {
-                        debug(.default, "Cannot gracefully unwrap alertTreatmentToDelete!")
-                        return
-                    }
-                    let treatmentObjectID = treatmentToDelete.objectID
-                    state.invokeInsulinDeletionTask(treatmentObjectID)
-                }
-            } message: {
-                Text("\n" + alertMessage)
             }
         }
 
@@ -1116,29 +1054,7 @@ extension History {
                     "Delete",
                     systemImage: "trash.fill",
                     role: .none,
-                    action: {
-                        alertCarbEntryToDelete = meal
-                        if meal.fpuID == nil {
-                            alertTitle = String(localized: "Delete Carbs?", comment: "Alert title for deleting carbs")
-                            alertMessage = Formatter.dateFormatter
-                                .string(from: meal.date ?? Date()) + ", " +
-                                (Formatter.decimalFormatterWithTwoFractionDigits.string(for: meal.carbs) ?? "0") +
-                                String(localized: " g", comment: "gram of carbs")
-                        } else {
-                            alertTitle = meal.isFPU ? String(
-                                localized: "Delete Carbs Equivalents?",
-                                comment: "Alert title for deleting carb equivalents"
-                            )
-                                : String(localized: "Delete Carbs?", comment: "Alert title for deleting carbs")
-                            alertMessage = String(
-                                localized: "All FPUs and the carbs of the meal will be deleted.",
-                                comment: "Alert message for meal deletion"
-                            )
-                        }
-
-                        // Use separate alert for meals
-                        isRemoveMealAlertPresented = true
-                    }
+                    action: { deletionTarget = .carbs(meal) }
                 ).tint(.red)
 
                 Button(
@@ -1152,27 +1068,6 @@ extension History {
                 )
                 .tint(!state.useFPUconversion && isFPU ? Color(.systemGray4) : Color.blue)
                 .disabled(!state.useFPUconversion && isFPU)
-            }
-            // Use separate alert for meals
-            .alert(
-                Text(alertTitle),
-                isPresented: $isRemoveMealAlertPresented
-            ) {
-                Button("Cancel", role: .cancel) {}
-                Button("Delete", role: .destructive) {
-                    guard let carbEntryToDelete = alertCarbEntryToDelete else {
-                        debug(.default, "Cannot gracefully unwrap alertCarbEntryToDelete!")
-                        return
-                    }
-                    let treatmentObjectID = carbEntryToDelete.objectID
-                    state.invokeCarbDeletionTask(
-                        treatmentObjectID,
-                        isFpuOrComplexMeal: carbEntryToDelete.isFPU || carbEntryToDelete.fat > 0 || carbEntryToDelete
-                            .protein > 0
-                    )
-                }
-            } message: {
-                Text("\n" + alertMessage)
             }
         }
 


### PR DESCRIPTION
## Unify history item deletion prompts

### Problem

In History, deleting a glucose reading, an insulin (pump) event, or a carb entry was handled by three separate `.alert` modifiers that shared state. The alerts could misfire or interfere with each other, and the title/message logic for the confirmation prompt was scattered across call sites in `HistoryRootView`.

### Root cause

Each deletion path attached its own `.alert` to a different part of the view tree while mutating overlapping `@State` values. With several alerts competing over shared state, SwiftUI could present the wrong confirmation — or none — depending on which tab (meals vs. combined treatments) triggered the delete swipe. Carb deletion is additionally routed through both tabs, doubling the chance of a conflict.

### Fix

Introduce `History.DeletionTarget` (`Trio/Sources/Modules/History/HistoryDeletionTarget.swift`) as the single source of truth for the item about to be deleted:

- One enum case per deletable row: `.glucose(GlucoseStored)`, `.insulin(PumpEventStored)`, `.carbs(CarbEntryStored)`; both the meals tab and the combined treatments tab route carb deletion through the same `.carbs` case.
- The enum centralizes `title` and `message(units:)`, so alert copy lives in exactly one place. `message(units:)` now returns a non-optional `String` (it has no other callers).
- New `isFpuOrComplexMeal` property flags carb entries whose deletion cascades to FPU rows, so `HistoryRootView` can pass it straight into `invokeCarbDeletionTask(_:isFpuOrComplexMeal:)`.
- `HistoryRootView` now presents a single `glassActionSheet` for all deletion confirmations instead of three competing `.alert` modifiers.

Net −97 lines (43 insertions, 140 deletions) across `HistoryDeletionTarget.swift`, `HistoryRootView.swift` and `Localizable.xcstrings`. No model, settings, or submodule changes.

### Not included

- No change to what gets deleted or to Core Data — presentation logic only.
- Scheduled-basal visualization and pump-event finalization test coverage from the same Tai-dev feature line are intentionally excluded here; they depend on the finalized-pump-events base that is still in upstream review (nightscout/Trio#1300) and will follow via the normal upstream sync once merged.

### Testing

- Cherry-picked cleanly onto current `dev`; no conflicts.
- Deletion flows for glucose, insulin, carb, and FPU/complex-meal entries verified on the originating Tai-dev branch (simulator).

### Screenshots

_Screenshots of the unified deletion confirmation to be attached._
