### PR TITLE
fix: preserve pump rounding across Decimal conversions

### DIFF
--- a/Trio/Sources/APS/APSManager.swift
+++ b/Trio/Sources/APS/APSManager.swift
@@ -396,7 +396,7 @@ final class BaseAPSManager: APSManager, Injectable {
             "Concentration: Bolus \(roundedVolume) U adjusted to U\(Int(settings.insulinConcentration * 100))-Volume of \(convertedVolume)"
         )
 
-        return Double(truncating: convertedVolume as NSNumber)
+        return convertedVolume.nearestDouble
     }
 
     private func adjustPumpedRateToConcentration(_ rate: Double) -> Double {
@@ -410,7 +410,7 @@ final class BaseAPSManager: APSManager, Injectable {
             "Concentration: Rate \(roundedRate) IU/hr adjusted to U\(Int(settings.insulinConcentration * 100))-Rate of \(convertedRate)"
         )
 
-        return Double(truncating: convertedRate as NSNumber)
+        return convertedRate.nearestDouble
     }
 
     private func adjustPumpedRateToU100(_ rate: Decimal) -> Decimal {
@@ -630,11 +630,12 @@ final class BaseAPSManager: APSManager, Injectable {
         }
     }
 
-    /// The paired pump's deliverable basal rates, for the algorithm to round against.
-    /// Rounded to 3 dp because the kits build their tables as `Double(n) / 20` and similar, and the
-    /// resulting binary error would push an entry just above the clean rate it is meant to match.
+    /// The paired pump's deliverable basal rates, for the algorithm to round against, in U100
+    /// units. Normalize before scaling so conversion back to pump units lands on the pump's own
+    /// table exactly.
     private var supportedBasalRates: [Decimal] {
-        (pumpManager?.supportedBasalRates ?? []).map { Decimal($0).rounded(scale: 3) }
+        let concentration = settings.insulinConcentration
+        return (pumpManager?.supportedBasalRates ?? []).map { Decimal($0).rounded(scale: 3) * concentration }
     }
 
     func roundBolus(amount: Decimal) -> Decimal {
@@ -671,7 +672,9 @@ final class BaseAPSManager: APSManager, Injectable {
             return
         }
 
-        let roundedAmount = pump.roundToSupportedBolusVolume(units: adjustPumpedVolumeToConcentration(amount))
+        let roundedAmount = pump.roundToSupportedBolusVolume(
+            units: adjustPumpedVolumeToConcentration(amount).deliverable
+        )
 
         debug(.apsManager, "Enact bolus \(roundedAmount), manual \(!isSMB)")
 
@@ -765,7 +768,7 @@ final class BaseAPSManager: APSManager, Injectable {
         debug(.apsManager, "Enact temp basal \(safeRate) - \(duration)")
 
         let adjustedRate = adjustPumpedRateToConcentration(safeRate)
-        let roundedRate = pump.roundToSupportedBasalRate(unitsPerHour: adjustedRate)
+        let roundedRate = pump.roundToSupportedBasalRate(unitsPerHour: adjustedRate.deliverable)
 
         do {
             try await pump.enactTempBasal(unitsPerHour: roundedRate, for: duration)
@@ -849,14 +852,18 @@ final class BaseAPSManager: APSManager, Injectable {
         if let rate = rateDecimal, let duration = durationInSeconds {
             let requestedRate = rate.doubleValue
             let adjustedRate = requestedRate > 0 ? pump
-                .roundToSupportedBasalRate(unitsPerHour: adjustPumpedRateToConcentration(requestedRate)) : requestedRate
+                .roundToSupportedBasalRate(
+                    unitsPerHour: adjustPumpedRateToConcentration(requestedRate).deliverable
+                ) : requestedRate
             try await performBasal(pump: pump, rate: NSDecimalNumber(value: adjustedRate), duration: duration)
         }
 
         // only perform a bolus if smbToDeliver is > 0
         if let smb = smbToDeliver, smb.compare(NSDecimalNumber(value: 0)) == .orderedDescending {
             let smbAmount = Double(truncating: smb)
-            let adjustedSMBAmount = pump.roundToSupportedBolusVolume(units: adjustPumpedVolumeToConcentration(smbAmount))
+            let adjustedSMBAmount = pump.roundToSupportedBolusVolume(
+                units: adjustPumpedVolumeToConcentration(smbAmount).deliverable
+            )
             let finalSMBAmount = NSDecimalNumber(value: adjustedSMBAmount) // Convert to NSDecimalNumber
             try await performBolus(pump: pump, smbToDeliver: finalSMBAmount)
         }

--- a/Trio/Sources/APS/Extensions/PumpManagerExtensions.swift
+++ b/Trio/Sources/APS/Extensions/PumpManagerExtensions.swift
@@ -12,6 +12,18 @@ extension PumpManager {
     }
 }
 
+/// The Double a pump driver should round against when the caller only holds a `Double`.
+///
+/// Decimal-to-Double conversion can place an intended table value just below its binary Double
+/// representation. Pump drivers floor against their tables, so that tiny error can lose a full
+/// pump step. Five decimal places preserve every supported pump/concentration rate while
+/// recovering the intended table value.
+extension Double {
+    var deliverable: Double {
+        Decimal(self).precisionRounded(scale: 5).nearestDouble
+    }
+}
+
 extension PumpManagerUI {
     func settingsViewController(
         bluetoothProvider: BluetoothProvider,

--- a/Trio/Sources/APS/OpenAPSSwift/DetermineBasal/TempBasalFunctions.swift
+++ b/Trio/Sources/APS/OpenAPSSwift/DetermineBasal/TempBasalFunctions.swift
@@ -12,15 +12,24 @@ enum TempBasalFunctionError: LocalizedError, Equatable {
 }
 
 enum TempBasalFunctions {
-    /// Rounds a basal rate down to the nearest rate the paired pump can deliver, mirroring
-    /// `PumpManager.roundToSupportedBasalRate`, which is applied again at enactment.
+    /// Rounds a basal rate to the nearest rate the paired pump can deliver.
+    ///
+    /// Nearest, not floored as `PumpManager.roundToSupportedBasalRate` does: on a uniform grid it
+    /// reproduces JS `round-basal.js`, which rounds half up. Zero seeds the search because every
+    /// pump can hold a zero temp, and a pod's table starts at 0.05 without listing one.
     static func roundBasal(profile: Profile, basalRate: Decimal) -> Decimal {
-        // no pump paired: leave the rate alone beyond keeping reason strings readable
+        // No pump paired: leave the rate alone beyond keeping reason strings readable. Keep five
+        // decimal places because a concentrated-insulin rate can carry two digits beyond a U100
+        // pump rate.
         guard !profile.supportedBasalRates.isEmpty else {
-            return basalRate.rounded(scale: 3, roundingMode: .down)
+            return basalRate.rounded(scale: 5, roundingMode: .down)
         }
 
-        return profile.supportedBasalRates.lazy.filter { $0 <= basalRate }.max() ?? 0
+        return profile.supportedBasalRates.reduce(0) { nearest, rate in
+            let distance = abs(rate - basalRate)
+            let nearestDistance = abs(nearest - basalRate)
+            return distance < nearestDistance || (distance == nearestDistance && rate > nearest) ? rate : nearest
+        }
     }
 
     /// defines the max safe basal rate given a profile

--- a/Trio/Sources/APS/PumpIncrementResolver.swift
+++ b/Trio/Sources/APS/PumpIncrementResolver.swift
@@ -19,8 +19,8 @@ enum PumpIncrementResolver {
         currentIncrement: Decimal,
         concentration: Decimal
     ) -> Decimal {
-        let supportedPumpIncrement = Decimal(supportedBolusVolumes.first ?? 0.1)
-        var bolusIncrement = Decimal(supportedBolusVolumes.first ?? Double(currentIncrement))
+        let supportedPumpIncrement = Decimal(supportedBolusVolumes.first ?? 0.1).rounded(scale: 3)
+        var bolusIncrement = Decimal(supportedBolusVolumes.first ?? Double(currentIncrement)).rounded(scale: 3)
 
         if concentration != 1 {
             bolusIncrement = supportedPumpIncrement * concentration
@@ -39,7 +39,7 @@ enum PumpIncrementResolver {
     /// - Parameter supportedBasalRates: `PumpManager.supportedBasalRates`, which starts at 0 on
     ///   pumps that allow a zero scheduled rate, so the first positive entry is the step.
     static func resolveBasal(supportedBasalRates: [Double], concentration: Decimal) -> Decimal {
-        let step = supportedBasalRates.first(where: { $0 > 0 }).map { Decimal($0) } ?? basalFallback
+        let step = supportedBasalRates.first(where: { $0 > 0 }).map { Decimal($0).rounded(scale: 3) } ?? basalFallback
         return step * concentration
     }
 }

--- a/Trio/Sources/Modules/AdaptProfile/AdaptProfileProvider.swift
+++ b/Trio/Sources/Modules/AdaptProfile/AdaptProfileProvider.swift
@@ -250,7 +250,7 @@ extension AdaptProfile {
         }
 
         var supportedBasalRates: [Decimal]? {
-            deviceManager.pumpManager?.supportedBasalRates.map { Decimal($0) }
+            deviceManager.pumpManager?.supportedBasalRates.map { Decimal($0).rounded(scale: 3) }
         }
 
         func activate(

--- a/Trio/Sources/Modules/BasalProfileEditor/BasalProfileEditorProvider.swift
+++ b/Trio/Sources/Modules/BasalProfileEditor/BasalProfileEditorProvider.swift
@@ -18,7 +18,7 @@ extension BasalProfileEditor {
             // from this list.
             deviceManager.pumpManager?.supportedBasalRates
                 .filter { $0 > 0 }
-                .map { Decimal($0) }
+                .map { Decimal($0).rounded(scale: 3) }
         }
 
         func saveProfile(_ profile: [BasalProfileEntry]) -> AnyPublisher<Void, Error> {

--- a/Trio/Sources/Modules/Onboarding/OnboardingStateModel.swift
+++ b/Trio/Sources/Modules/Onboarding/OnboardingStateModel.swift
@@ -738,7 +738,7 @@ extension Onboarding {
                             settingsManager.preferences
                                 .bolusIncrement
                         )
-                )
+                ).rounded(scale: 3)
                 preferences.bolusIncrement = bolusIncrement > 0 ? bolusIncrement : 0.1
             }
 

--- a/TrioTests/BasalRoundingDriverParityTests.swift
+++ b/TrioTests/BasalRoundingDriverParityTests.swift
@@ -6,10 +6,10 @@ import Testing
 
 @testable import Trio
 
-/// Pins `TempBasalFunctions.roundBasal` against the real pump kits' own rate tables, so the
-/// algorithm and `PumpManager.roundToSupportedBasalRate` can never disagree about what the
-/// paired pump can deliver. `RoundBasalTests` covers the same shapes arithmetically for the
-/// algorithm-only SPM target, which cannot import the kits.
+/// Pins `TempBasalFunctions.roundBasal` against the real pump kits' own rate tables. The
+/// algorithm rounds to nearest while drivers floor, so the guarantee is that every rate the
+/// algorithm commits to survives the driver unchanged. `RoundBasalTests` covers the same table
+/// shapes arithmetically for the algorithm-only SPM target, which cannot import the kits.
 @Suite("Basal Rounding Driver Parity") struct BasalRoundingDriverParityTests {
     /// Mirrors `APSManager.supportedBasalRates`: the 3 dp normalisation is what keeps a
     /// `Double(n) / 20` table entry from landing just above the clean rate it represents.
@@ -17,14 +17,15 @@ import Testing
         rates.map { Decimal($0).rounded(scale: 3) }
     }
 
-    private func rates(for table: [Double]) -> (algorithm: (Decimal) -> Decimal, driver: (Double) -> Double) {
+    private func driver(_ table: [Double], _ unitsPerHour: Decimal) -> Decimal {
+        let requested = Double(truncating: unitsPerHour as NSNumber).deliverable
+        return Decimal(table.last(where: { $0 <= requested }) ?? 0).rounded(scale: 3)
+    }
+
+    private func algorithm(_ table: [Decimal], _ rate: Decimal) -> Decimal {
         var profile = Profile()
-        profile.supportedBasalRates = normalised(table)
-        return (
-            algorithm: { TempBasalFunctions.roundBasal(profile: profile, basalRate: $0) },
-            // the shape every kit implements, and LoopKit's default
-            driver: { unitsPerHour in table.last(where: { $0 <= unitsPerHour }) ?? 0 }
-        )
+        profile.supportedBasalRates = table
+        return TempBasalFunctions.roundBasal(profile: profile, basalRate: rate)
     }
 
     /// Values chosen to land on, just below, and just above real table steps.
@@ -33,33 +34,43 @@ import Testing
         1, 1.03, 1.23, 2.5, 3, 3.01, 5.375, 9.95, 10, 10.05, 10.06, 24.9, 30, 35, 40
     ]
 
-    @Test("matches every kit's own table", arguments: [
+    private static let tables: [(String, [Double])] = [
         ("Minimed 723 (gen >= 23)", PumpModel.model723.supportedBasalRates),
         ("Minimed 522 (pre-x23)", PumpModel.model522.supportedBasalRates),
         ("Dana", DanaKitPumpManager.onboardingSupportedBasalRates),
         ("Medtrum", MedtrumPumpManager.onboardingSupportedBasalRates),
         // Pod's table is a local inside OmnipodKit's BasalDeliveryTable, so replicate Eros here
         ("Omnipod Eros", (1 ... 600).map { Double($0) / 20 })
-    ]) func matchesDriver(pump: String, table: [Double]) {
-        let (algorithm, driver) = rates(for: table)
+    ]
 
+    @Test("the algorithm's rate survives the driver", arguments: tables) func survivesDriver(pump: String, table: [Double]) {
         for probe in Self.probes {
-            let mine = algorithm(probe)
-            let theirs = Decimal(driver(Double(truncating: probe as NSNumber))).rounded(scale: 3)
-            #expect(mine == theirs, "\(pump) disagrees at \(probe): algorithm \(mine), driver \(theirs)")
+            let mine = algorithm(normalised(table), probe)
+            #expect(driver(table, mine) == mine, "\(pump) floors \(mine) away at probe \(probe)")
+        }
+
+        for rate in normalised(table) {
+            #expect(driver(table, rate) == rate, "\(pump) floors \(rate) away")
+        }
+    }
+
+    @Test("a scaled rate divides back onto the table", arguments: tables) func survivesDilution(pump: String, table: [Double]) {
+        for concentration in [Decimal(2), 5, 0.5, 0.1] {
+            let scaled = normalised(table).map { $0 * concentration }
+            for probe in Self.probes {
+                let pumpVolume = algorithm(scaled, probe) / concentration
+                #expect(driver(table, pumpVolume) == pumpVolume, "\(pump) at U\(concentration * 100) loses \(pumpVolume)")
+            }
         }
     }
 
     /// The rate `APSManager.performBasal` hands over must be the *same* `Double` the driver's own
     /// table holds. `Double(truncating:)` lands below on 41 of Dana's 301 rates (0.07 becomes
     /// 0.06999999999999999), and since every table floors, that silently costs a full increment.
-    @Test("the rate handed to the driver survives the Decimal to Double hop", arguments: [
-        ("Minimed 723 (gen >= 23)", PumpModel.model723.supportedBasalRates),
-        ("Minimed 522 (pre-x23)", PumpModel.model522.supportedBasalRates),
-        ("Dana", DanaKitPumpManager.onboardingSupportedBasalRates),
-        ("Medtrum", MedtrumPumpManager.onboardingSupportedBasalRates),
-        ("Omnipod Eros", (1 ... 600).map { Double($0) / 20 })
-    ]) func handedOverRateSurvivesConversion(pump: String, table: [Double]) {
+    @Test(
+        "the rate handed to the driver survives the Decimal to Double hop",
+        arguments: tables
+    ) func handedOverRateSurvivesConversion(pump: String, table: [Double]) {
         for entry in table {
             // what roundBasal returns: the injected table entry, an exact 3 dp Decimal
             let algorithmRate = Decimal(entry).rounded(scale: 3)
@@ -85,12 +96,7 @@ import Testing
     }
 
     @Test("every kit table is non-empty and normalises without collisions") func tablesNormaliseCleanly() {
-        for table in [
-            PumpModel.model723.supportedBasalRates,
-            PumpModel.model522.supportedBasalRates,
-            DanaKitPumpManager.onboardingSupportedBasalRates,
-            MedtrumPumpManager.onboardingSupportedBasalRates
-        ] {
+        for (_, table) in Self.tables {
             let rates = normalised(table)
             #expect(!rates.isEmpty)
             // 3 dp must not merge two distinct rates into one

--- a/TrioTests/OpenAPSSwiftTests/Parity/ParityInputs.swift
+++ b/TrioTests/OpenAPSSwiftTests/Parity/ParityInputs.swift
@@ -30,9 +30,7 @@ enum ParityInputs {
         ]
     }
 
-    /// The Minimed gen ≥23 table the goldens were originally recorded against. The only
-    /// remaining difference from oref's `round-basal.js` is that the algorithm now floors
-    /// instead of rounding to nearest.
+    /// The Minimed gen ≥23 table the goldens were originally recorded against.
     static func supportedBasalRates() -> [Decimal] {
         PumpRateTables.minimedGen23
     }

--- a/TrioTests/OpenAPSSwiftTests/Parity/goldens/autosens-resistance+autoisf-off/determination.json
+++ b/TrioTests/OpenAPSSwiftTests/Parity/goldens/autosens-resistance+autoisf-off/determination.json
@@ -165,7 +165,7 @@
       126
     ]
   },
-  "rate" : 0.25,
+  "rate" : 0.275,
   "reason" : "Ins.Req:, 0.55, SMB Del.Ratio:, 0.5, autosens:, 1, autoISF disabled, Standard, COB: 0, Dev: 37, BGI: -4, CR: 12, Target: 95, minPredBG 125, minGuardBG 134, IOBpredBG 108, UAMpredBG 135; Eventual BG 135 >= 95,  insulinReq 0.55; setting 30m low temp of 0.27U/h. Microbolusing 0.25U. ",
   "received" : false,
   "sensitivityRatio" : 1,

--- a/TrioTests/OpenAPSSwiftTests/Parity/goldens/autosens-resistance+autoisf-off/profile.json
+++ b/TrioTests/OpenAPSSwiftTests/Parity/goldens/autosens-resistance+autoisf-off/profile.json
@@ -146,7 +146,6 @@
   "max_iob" : 6,
   "min_5m_carbimpact" : 8,
   "min_bg" : 95,
-  "model" : "722",
   "noisyCGMTargetMultiplier" : 1.3,
   "out_units" : "mg/dL",
   "pp_ISF_weight" : 0.02,

--- a/TrioTests/OpenAPSSwiftTests/Parity/goldens/autosens-sensitivity+autoisf-off/profile.json
+++ b/TrioTests/OpenAPSSwiftTests/Parity/goldens/autosens-sensitivity+autoisf-off/profile.json
@@ -146,7 +146,6 @@
   "max_iob" : 6,
   "min_5m_carbimpact" : 8,
   "min_bg" : 95,
-  "model" : "722",
   "noisyCGMTargetMultiplier" : 1.3,
   "out_units" : "mg/dL",
   "pp_ISF_weight" : 0.02,

--- a/TrioTests/OpenAPSSwiftTests/Parity/goldens/dense-pump-history-24h+autoisf-off/determination.json
+++ b/TrioTests/OpenAPSSwiftTests/Parity/goldens/dense-pump-history-24h+autoisf-off/determination.json
@@ -20,7 +20,7 @@
   "eventualBG" : 102,
   "expectedDelta" : -3.9,
   "id" : "00000000-0000-0000-0000-000000000000",
-  "insulinReq" : 0,
+  "insulinReq" : 0.025,
   "iobActivity" : 0.0152,
   "minDelta" : 5.7222,
   "minGuardBG" : 102,
@@ -171,8 +171,8 @@
       95
     ]
   },
-  "rate" : 0,
-  "reason" : "SMB Del.Ratio:, 0.5, autosens:, 1, autoISF disabled, Standard, COB: 0, Dev: 59, BGI: -4, CR: 12, Target: 95, minPredBG 96, minGuardBG 102, IOBpredBG 92, UAMpredBG 102; Eventual BG 102 >= 95,  insulinReq 0; setting 30m low temp of 0U/h. ",
+  "rate" : 0.95,
+  "reason" : "Ins.Req:, 0.025, SMB Del.Ratio:, 0.5, autosens:, 1, autoISF disabled, Standard, COB: 0, Dev: 59, BGI: -4, CR: 12, Target: 95, minPredBG 96, minGuardBG 102, IOBpredBG 92, UAMpredBG 102; Eventual BG 102 >= 95,  insulinReq 0.025. temp 0.75<0.95U/hr. ",
   "received" : false,
   "sensitivityRatio" : 1,
   "temp" : "absolute",

--- a/TrioTests/OpenAPSSwiftTests/Parity/goldens/dense-pump-history-24h+autoisf-off/profile.json
+++ b/TrioTests/OpenAPSSwiftTests/Parity/goldens/dense-pump-history-24h+autoisf-off/profile.json
@@ -146,7 +146,6 @@
   "max_iob" : 6,
   "min_5m_carbimpact" : 8,
   "min_bg" : 95,
-  "model" : "722",
   "noisyCGMTargetMultiplier" : 1.3,
   "out_units" : "mg/dL",
   "pp_ISF_weight" : 0.02,

--- a/TrioTests/OpenAPSSwiftTests/Parity/goldens/dynamic-isf-logarithmic+autoisf-off/profile.json
+++ b/TrioTests/OpenAPSSwiftTests/Parity/goldens/dynamic-isf-logarithmic+autoisf-off/profile.json
@@ -146,7 +146,6 @@
   "max_iob" : 6,
   "min_5m_carbimpact" : 8,
   "min_bg" : 95,
-  "model" : "722",
   "noisyCGMTargetMultiplier" : 1.3,
   "out_units" : "mg/dL",
   "pp_ISF_weight" : 0.02,

--- a/TrioTests/OpenAPSSwiftTests/Parity/goldens/dynamic-isf-sigmoid+autoisf-off/determination.json
+++ b/TrioTests/OpenAPSSwiftTests/Parity/goldens/dynamic-isf-sigmoid+autoisf-off/determination.json
@@ -166,7 +166,7 @@
       98
     ]
   },
-  "reason" : "Ins.Req:, 0.4, SMB Del.Ratio:, 0.5, autosens:, 1.15, autoISF disabled, Standard, COB: 0, Dev: 56, BGI: -4, CR: 12, Target: 95, minPredBG 114, minGuardBG 125, IOBpredBG 104, UAMpredBG 125, Dynamic ISF: On, Sigmoid function, AF: 0.6, Basal ratio: 1.01; Eventual BG 125 >= 95,  insulinReq 0.4; setting 30m low temp of 0.87U/h. Microbolusing 0.2U.  30m left and 0.75 ~ req 0.85U/hr: no temp required",
+  "reason" : "Ins.Req:, 0.4, SMB Del.Ratio:, 0.5, autosens:, 1.15, autoISF disabled, Standard, COB: 0, Dev: 56, BGI: -4, CR: 12, Target: 95, minPredBG 114, minGuardBG 125, IOBpredBG 104, UAMpredBG 125, Dynamic ISF: On, Sigmoid function, AF: 0.6, Basal ratio: 1.01; Eventual BG 125 >= 95,  insulinReq 0.4; setting 30m low temp of 0.87U/h. Microbolusing 0.2U.  30m left and 0.75 ~ req 0.875U/hr: no temp required",
   "received" : false,
   "sensitivityRatio" : 1.152552507138643740284,
   "temp" : "absolute",

--- a/TrioTests/OpenAPSSwiftTests/Parity/goldens/dynamic-isf-sigmoid+autoisf-off/profile.json
+++ b/TrioTests/OpenAPSSwiftTests/Parity/goldens/dynamic-isf-sigmoid+autoisf-off/profile.json
@@ -146,7 +146,6 @@
   "max_iob" : 6,
   "min_5m_carbimpact" : 8,
   "min_bg" : 95,
-  "model" : "722",
   "noisyCGMTargetMultiplier" : 1.3,
   "out_units" : "mg/dL",
   "pp_ISF_weight" : 0.02,

--- a/TrioTests/OpenAPSSwiftTests/Parity/goldens/high-bg-rising-smb+autoisf-off/determination.json
+++ b/TrioTests/OpenAPSSwiftTests/Parity/goldens/high-bg-rising-smb+autoisf-off/determination.json
@@ -20,7 +20,7 @@
   "eventualBG" : 163,
   "expectedDelta" : -7,
   "id" : "00000000-0000-0000-0000-000000000000",
-  "insulinReq" : 0.95,
+  "insulinReq" : 0.975,
   "iobActivity" : 0.0152,
   "minDelta" : 8,
   "minGuardBG" : 107,
@@ -165,8 +165,8 @@
       149
     ]
   },
-  "rate" : 2.8,
-  "reason" : "Ins.Req:, 0.95, SMB Del.Ratio:, 0.5, autosens:, 1, autoISF disabled, Standard, COB: 0, Dev: 73, BGI: -4, CR: 12, Target: 95, minPredBG 148, minGuardBG 107, IOBpredBG 161, UAMpredBG 108; Eventual BG 163 >= 95,  insulinReq 0.95. Microbolusing 0.45U. temp 0.75<2.8U/hr. ",
+  "rate" : 2.85,
+  "reason" : "Ins.Req:, 0.975, SMB Del.Ratio:, 0.5, autosens:, 1, autoISF disabled, Standard, COB: 0, Dev: 73, BGI: -4, CR: 12, Target: 95, minPredBG 148, minGuardBG 107, IOBpredBG 161, UAMpredBG 108; Eventual BG 163 >= 95,  insulinReq 0.975. Microbolusing 0.45U. temp 0.75<2.85U/hr. ",
   "received" : false,
   "sensitivityRatio" : 1,
   "temp" : "absolute",

--- a/TrioTests/OpenAPSSwiftTests/Parity/goldens/high-bg-rising-smb+autoisf-off/profile.json
+++ b/TrioTests/OpenAPSSwiftTests/Parity/goldens/high-bg-rising-smb+autoisf-off/profile.json
@@ -146,7 +146,6 @@
   "max_iob" : 6,
   "min_5m_carbimpact" : 8,
   "min_bg" : 95,
-  "model" : "722",
   "noisyCGMTargetMultiplier" : 1.3,
   "out_units" : "mg/dL",
   "pp_ISF_weight" : 0.02,

--- a/TrioTests/OpenAPSSwiftTests/Parity/goldens/low-bg-falling+autoisf-off/profile.json
+++ b/TrioTests/OpenAPSSwiftTests/Parity/goldens/low-bg-falling+autoisf-off/profile.json
@@ -146,7 +146,6 @@
   "max_iob" : 6,
   "min_5m_carbimpact" : 8,
   "min_bg" : 95,
-  "model" : "722",
   "noisyCGMTargetMultiplier" : 1.3,
   "out_units" : "mg/dL",
   "pp_ISF_weight" : 0.02,

--- a/TrioTests/OpenAPSSwiftTests/Parity/goldens/override-active+autoisf-off/determination.json
+++ b/TrioTests/OpenAPSSwiftTests/Parity/goldens/override-active+autoisf-off/determination.json
@@ -168,7 +168,7 @@
       104
     ]
   },
-  "rate" : 0.4,
+  "rate" : 0.375,
   "reason" : "Ins.Req:, 0.7, SMB Del.Ratio:, 0.5, autosens:, 1, autoISF disabled, Standard, COB: 0, Dev: 54, BGI: -3, CR: 12→9.2, Target: 90, minPredBG 120, minGuardBG 128, IOBpredBG 112, UAMpredBG 128; Eventual BG 128 >= 90,  insulinReq 0.7; setting 30m low temp of 0.38U/h. Microbolusing 0.35U. ",
   "received" : false,
   "sensitivityRatio" : 1,

--- a/TrioTests/OpenAPSSwiftTests/Parity/goldens/override-active+autoisf-off/profile.json
+++ b/TrioTests/OpenAPSSwiftTests/Parity/goldens/override-active+autoisf-off/profile.json
@@ -146,7 +146,6 @@
   "max_iob" : 6,
   "min_5m_carbimpact" : 8,
   "min_bg" : 95,
-  "model" : "722",
   "noisyCGMTargetMultiplier" : 1.3,
   "out_units" : "mg/dL",
   "pp_ISF_weight" : 0.02,

--- a/TrioTests/OpenAPSSwiftTests/Parity/goldens/post-meal-cob-active+autoisf-off/determination.json
+++ b/TrioTests/OpenAPSSwiftTests/Parity/goldens/post-meal-cob-active+autoisf-off/determination.json
@@ -20,7 +20,7 @@
   "eventualBG" : 168,
   "expectedDelta" : -4.9,
   "id" : "00000000-0000-0000-0000-000000000000",
-  "insulinReq" : 0.85,
+  "insulinReq" : 0.825,
   "iobActivity" : 0.0152,
   "minDelta" : 7,
   "minGuardBG" : 141,
@@ -216,8 +216,8 @@
       104
     ]
   },
-  "rate" : 0.55,
-  "reason" : "Ins.Req:, 0.85, SMB Del.Ratio:, 0.5, autosens:, 1, autoISF disabled, Standard, COB: 26, Dev: 67, BGI: -4, CR: 12, Target: 95, minPredBG 141, minGuardBG 141, IOBpredBG 114, COBpredBG 168, UAMpredBG 105; Eventual BG 168 >= 95,  insulinReq 0.85; setting 30m low temp of 0.57U/h. Microbolusing 0.4U. ",
+  "rate" : 0.575,
+  "reason" : "Ins.Req:, 0.825, SMB Del.Ratio:, 0.5, autosens:, 1, autoISF disabled, Standard, COB: 26, Dev: 67, BGI: -4, CR: 12, Target: 95, minPredBG 141, minGuardBG 141, IOBpredBG 114, COBpredBG 168, UAMpredBG 105; Eventual BG 168 >= 95,  insulinReq 0.825; setting 30m low temp of 0.57U/h. Microbolusing 0.4U. ",
   "received" : false,
   "sensitivityRatio" : 1,
   "temp" : "absolute",

--- a/TrioTests/OpenAPSSwiftTests/Parity/goldens/post-meal-cob-active+autoisf-off/profile.json
+++ b/TrioTests/OpenAPSSwiftTests/Parity/goldens/post-meal-cob-active+autoisf-off/profile.json
@@ -146,7 +146,6 @@
   "max_iob" : 6,
   "min_5m_carbimpact" : 8,
   "min_bg" : 95,
-  "model" : "722",
   "noisyCGMTargetMultiplier" : 1.3,
   "out_units" : "mg/dL",
   "pp_ISF_weight" : 0.02,

--- a/TrioTests/OpenAPSSwiftTests/Parity/goldens/post-meal-cob-active/determination.json
+++ b/TrioTests/OpenAPSSwiftTests/Parity/goldens/post-meal-cob-active/determination.json
@@ -20,7 +20,7 @@
   "eventualBG" : 168,
   "expectedDelta" : -4.9,
   "id" : "00000000-0000-0000-0000-000000000000",
-  "insulinReq" : 0.8,
+  "insulinReq" : 0.825,
   "iobActivity" : 0.0152,
   "iob_THeffective" : 6,
   "minDelta" : 7,
@@ -217,8 +217,8 @@
       103
     ]
   },
-  "rate" : 2.5,
-  "reason" : "Ins.Req:, 0.8, SMB Del.Ratio:, 0.85, autosens:, 1, autoISF-SMB disabled:, odd Target, Parabolic Fit:, predicts Max of 191, in about 34min, acce-ISF Ratio:, 0.83, autoISF, bg-ISF Ratio: 1.17, pp-ISF Ratio: 1.14, final Ratio:, 0.97, final ISF:, 55→56, Standard, COB: 26, Dev: 68, BGI: -4, CR: 12, Target: 95, minPredBG 141, minGuardBG 140, IOBpredBG 112, COBpredBG 168, UAMpredBG 103; Eventual BG 168 >= 95, temp 0.75<2.5U/hr. ",
+  "rate" : 2.55,
+  "reason" : "Ins.Req:, 0.825, SMB Del.Ratio:, 0.85, autosens:, 1, autoISF-SMB disabled:, odd Target, Parabolic Fit:, predicts Max of 191, in about 34min, acce-ISF Ratio:, 0.83, autoISF, bg-ISF Ratio: 1.17, pp-ISF Ratio: 1.14, final Ratio:, 0.97, final ISF:, 55→56, Standard, COB: 26, Dev: 68, BGI: -4, CR: 12, Target: 95, minPredBG 141, minGuardBG 140, IOBpredBG 112, COBpredBG 168, UAMpredBG 103; Eventual BG 168 >= 95, temp 0.75<2.55U/hr. ",
   "received" : false,
   "sensitivityRatio" : 1,
   "temp" : "absolute",

--- a/TrioTests/OpenAPSSwiftTests/Parity/goldens/smb-disabled-temp-only+autoisf-off/determination.json
+++ b/TrioTests/OpenAPSSwiftTests/Parity/goldens/smb-disabled-temp-only+autoisf-off/determination.json
@@ -121,8 +121,8 @@
       95
     ]
   },
-  "rate" : 0.45,
-  "reason" : "SMB Del.Ratio:, 0.5, autosens:, 1, autoISF disabled, Standard, COB: 0, Dev: 59, BGI: -4, CR: 12, Target: 95, minPredBG 91, minGuardBG 91, IOBpredBG 92; Eventual BG 89 < 95, setting 0.45U/hr. ",
+  "rate" : 0.475,
+  "reason" : "SMB Del.Ratio:, 0.5, autosens:, 1, autoISF disabled, Standard, COB: 0, Dev: 59, BGI: -4, CR: 12, Target: 95, minPredBG 91, minGuardBG 91, IOBpredBG 92; Eventual BG 89 < 95, setting 0.475U/hr. ",
   "received" : false,
   "sensitivityRatio" : 1,
   "temp" : "absolute",

--- a/TrioTests/OpenAPSSwiftTests/Parity/goldens/smb-disabled-temp-only+autoisf-off/profile.json
+++ b/TrioTests/OpenAPSSwiftTests/Parity/goldens/smb-disabled-temp-only+autoisf-off/profile.json
@@ -146,7 +146,6 @@
   "max_iob" : 5,
   "min_5m_carbimpact" : 8,
   "min_bg" : 95,
-  "model" : "722",
   "noisyCGMTargetMultiplier" : 1.3,
   "out_units" : "mg/dL",
   "pp_ISF_weight" : 0.02,

--- a/TrioTests/OpenAPSSwiftTests/Parity/goldens/smb-disabled-temp-only/determination.json
+++ b/TrioTests/OpenAPSSwiftTests/Parity/goldens/smb-disabled-temp-only/determination.json
@@ -20,7 +20,7 @@
   "eventualBG" : 101,
   "expectedDelta" : -3.9,
   "id" : "00000000-0000-0000-0000-000000000000",
-  "insulinReq" : 0.1,
+  "insulinReq" : 0.125,
   "iobActivity" : 0.0152,
   "iob_THeffective" : 5,
   "minDelta" : 5.7222,
@@ -118,8 +118,8 @@
       97
     ]
   },
-  "rate" : 1.1,
-  "reason" : "Ins.Req:, 0.1, SMB Del.Ratio:, 0.85, autosens:, 1, autoISF-SMB disabled:, odd Target, acce-ISF Ratio:, 1.02, autoISF, bg-ISF Ratio: 1.13, pp-ISF Ratio: 1.12, final Ratio:, 1.13, final ISF:, 55→49, Standard, COB: 0, Dev: 57, BGI: -4, CR: 12, Target: 95, minPredBG 101, minGuardBG 101, IOBpredBG 102; Eventual BG 101 >= 95, temp 0.75<1.1U/hr. ",
+  "rate" : 1.15,
+  "reason" : "Ins.Req:, 0.125, SMB Del.Ratio:, 0.85, autosens:, 1, autoISF-SMB disabled:, odd Target, acce-ISF Ratio:, 1.02, autoISF, bg-ISF Ratio: 1.13, pp-ISF Ratio: 1.12, final Ratio:, 1.13, final ISF:, 55→49, Standard, COB: 0, Dev: 57, BGI: -4, CR: 12, Target: 95, minPredBG 101, minGuardBG 101, IOBpredBG 102; Eventual BG 101 >= 95, temp 0.75<1.15U/hr. ",
   "received" : false,
   "sensitivityRatio" : 1,
   "temp" : "absolute",

--- a/TrioTests/OpenAPSSwiftTests/Parity/goldens/stale-bg-error+autoisf-off/profile.json
+++ b/TrioTests/OpenAPSSwiftTests/Parity/goldens/stale-bg-error+autoisf-off/profile.json
@@ -146,7 +146,6 @@
   "max_iob" : 6,
   "min_5m_carbimpact" : 8,
   "min_bg" : 95,
-  "model" : "722",
   "noisyCGMTargetMultiplier" : 1.3,
   "out_units" : "mg/dL",
   "pp_ISF_weight" : 0.02,

--- a/TrioTests/OpenAPSSwiftTests/Parity/goldens/suspend-resume+autoisf-off/profile.json
+++ b/TrioTests/OpenAPSSwiftTests/Parity/goldens/suspend-resume+autoisf-off/profile.json
@@ -146,7 +146,6 @@
   "max_iob" : 6,
   "min_5m_carbimpact" : 8,
   "min_bg" : 95,
-  "model" : "722",
   "noisyCGMTargetMultiplier" : 1.3,
   "out_units" : "mg/dL",
   "pp_ISF_weight" : 0.02,

--- a/TrioTests/OpenAPSSwiftTests/Parity/goldens/temp-target-active+autoisf-off/profile.json
+++ b/TrioTests/OpenAPSSwiftTests/Parity/goldens/temp-target-active+autoisf-off/profile.json
@@ -147,7 +147,6 @@
   "max_iob" : 6,
   "min_5m_carbimpact" : 8,
   "min_bg" : 130,
-  "model" : "722",
   "noisyCGMTargetMultiplier" : 1.3,
   "out_units" : "mg/dL",
   "pp_ISF_weight" : 0.02,

--- a/TrioTests/OpenAPSSwiftTests/Parity/goldens/winter-standard-time+autoisf-off/determination.json
+++ b/TrioTests/OpenAPSSwiftTests/Parity/goldens/winter-standard-time+autoisf-off/determination.json
@@ -20,7 +20,7 @@
   "eventualBG" : 163,
   "expectedDelta" : -7,
   "id" : "00000000-0000-0000-0000-000000000000",
-  "insulinReq" : 0.95,
+  "insulinReq" : 0.975,
   "iobActivity" : 0.0152,
   "minDelta" : 8,
   "minGuardBG" : 107,
@@ -165,8 +165,8 @@
       149
     ]
   },
-  "rate" : 2.8,
-  "reason" : "Ins.Req:, 0.95, SMB Del.Ratio:, 0.5, autosens:, 1, autoISF disabled, Standard, COB: 0, Dev: 73, BGI: -4, CR: 12, Target: 95, minPredBG 148, minGuardBG 107, IOBpredBG 161, UAMpredBG 108; Eventual BG 163 >= 95,  insulinReq 0.95. Microbolusing 0.45U. temp 0.75<2.8U/hr. ",
+  "rate" : 2.85,
+  "reason" : "Ins.Req:, 0.975, SMB Del.Ratio:, 0.5, autosens:, 1, autoISF disabled, Standard, COB: 0, Dev: 73, BGI: -4, CR: 12, Target: 95, minPredBG 148, minGuardBG 107, IOBpredBG 161, UAMpredBG 108; Eventual BG 163 >= 95,  insulinReq 0.975. Microbolusing 0.45U. temp 0.75<2.85U/hr. ",
   "received" : false,
   "sensitivityRatio" : 1,
   "temp" : "absolute",

--- a/TrioTests/OpenAPSSwiftTests/Parity/goldens/winter-standard-time+autoisf-off/profile.json
+++ b/TrioTests/OpenAPSSwiftTests/Parity/goldens/winter-standard-time+autoisf-off/profile.json
@@ -146,7 +146,6 @@
   "max_iob" : 6,
   "min_5m_carbimpact" : 8,
   "min_bg" : 95,
-  "model" : "722",
   "noisyCGMTargetMultiplier" : 1.3,
   "out_units" : "mg/dL",
   "pp_ISF_weight" : 0.02,

--- a/TrioTests/OpenAPSSwiftTests/RoundBasalTests.swift
+++ b/TrioTests/OpenAPSSwiftTests/RoundBasalTests.swift
@@ -20,8 +20,8 @@ import Testing
         // the regression from issue #1424: the old bands turned this into 1.25
         #expect(round(1.23, PumpRateTables.dana) == 1.23)
         #expect(round(0.01, PumpRateTables.dana) == 0.01)
-        // built as Decimal(56) / 100: the literal 0.56 is parsed via Double and is not exact
-        #expect(round(0.567, PumpRateTables.dana) == Decimal(56) / 100)
+        // built as Decimal(57) / 100: the literal 0.57 is parsed via Double and is not exact
+        #expect(round(0.567, PumpRateTables.dana) == Decimal(57) / 100)
     }
 
     @Test("Dana clamps to the top of its table") func danaCeiling() {
@@ -34,9 +34,10 @@ import Testing
         #expect(round(10.05, PumpRateTables.minimedPre23) == 10.05)
     }
 
-    @Test("Omnipod Eros floors below its minimum rate to zero") func erosBelowMinimum() {
-        // the pod cannot deliver 0.03; the old bands claimed 0.05
-        #expect(round(0.03, PumpRateTables.omnipodEros) == 0)
+    @Test("Omnipod Eros rounds onto its own minimum or to zero") func erosBelowMinimum() {
+        // the pod's table has no zero, so zero has to come from the seed
+        #expect(round(0.01, PumpRateTables.omnipodEros) == 0)
+        #expect(round(0.03, PumpRateTables.omnipodEros) == 0.05)
         #expect(round(0.07, PumpRateTables.omnipodEros) == 0.05)
     }
 
@@ -44,28 +45,28 @@ import Testing
         // dead in production before this change: model.json was always "722"
         #expect(round(0.025, PumpRateTables.minimedGen23) == 0.025)
         #expect(round(0.03, PumpRateTables.minimedGen23) == 0.025)
-        #expect(round(1.03, PumpRateTables.minimedGen23) == 1.0)
-        #expect(round(10.06, PumpRateTables.minimedGen23) == 10.0)
+        #expect(round(1.03, PumpRateTables.minimedGen23) == 1.05)
+        #expect(round(10.06, PumpRateTables.minimedGen23) == 10.1)
     }
 
     @Test("no pump paired leaves the rate alone but keeps it readable") func noPump() {
         #expect(round(1.23, []) == 1.23)
-        #expect(round(12.345678, []) == 12.345)
+        #expect(round(12.345678, []) == 12.34567)
     }
 
     @Test("an unsorted or duplicated table gives the sorted answer") func unorderedTable() {
         let shuffled: [Decimal] = [1.0, 0.05, 0.5, 0.05, 0.1]
         #expect(round(0.6, shuffled) == 0.5)
-        #expect(round(0.04, shuffled) == 0)
+        #expect(round(0.04, shuffled) == 0.05)
     }
 
-    @Test("rounding never exceeds the requested rate", arguments: [
+    @Test("every result is a rate the pump can hold, within half a step", arguments: [
         Decimal(0), 0.011, 0.03, 0.4, 0.999, 1.0, 1.234, 5.375, 9.99, 10.06, 29.999
-    ]) func neverRoundsUp(rate: Decimal) {
+    ]) func landsOnTheTable(rate: Decimal) {
         for rates in [PumpRateTables.dana, PumpRateTables.omnipodEros, PumpRateTables.flat, PumpRateTables.minimedGen23] {
             let rounded = round(rate, rates)
-            #expect(rounded <= rate)
             #expect(rounded == 0 || rates.contains(rounded))
+            #expect(abs(rounded - rate) <= 0.05 || rate > rates[rates.count - 1])
         }
     }
 

--- a/TrioTests/OpenAPSSwiftTests/SetTempBasalTests.swift
+++ b/TrioTests/OpenAPSSwiftTests/SetTempBasalTests.swift
@@ -4,6 +4,19 @@ import Testing
 
 /// A direct port of the Javascript `set-temp-basal.test.js` tests
 @Suite("Set Temp Basal Tests") struct SetTempBasalTests {
+    static let pumpTables: [(String, [Decimal])] = [
+        ("Dana", PumpRateTables.dana),
+        ("Omnipod", PumpRateTables.flat),
+        ("Omnipod Eros", PumpRateTables.omnipodEros),
+        ("Minimed pre-x23", PumpRateTables.minimedPre23),
+        ("Minimed gen >= 23", PumpRateTables.minimedGen23)
+    ]
+
+    /// Sits on, either side of, and across the band edges a gen >= 23 table has at 1 and 10 U/hr.
+    static let bandProbes: [Decimal] = [
+        0.024, 0.03, 0.5, 0.975, 0.99, 1.03, 2.5, 5.375, 9.95, 9.99, 10.06, 11.9
+    ]
+
     /// Helper to create a default profile for tests.
     private func createProfile(
         currentBasal: Decimal = 0.8,
@@ -320,5 +333,31 @@ import Testing
         #expect(requestedTemp.rate == 0.8)
         #expect(requestedTemp.duration == 30)
         #expect(requestedTemp.reason == ". Setting neutral temp basal of 0.8U/hr")
+    }
+
+    @Test("the suggested rate is deliverable", arguments: pumpTables)
+    func deliverable(pump: String, rates: [Decimal]) throws {
+        let profile = createProfile(
+            currentBasal: 3,
+            maxDailyBasal: 4,
+            maxBasal: 12,
+            supportedBasalRates: rates
+        )
+        let ceiling = rates[rates.count - 1]
+        let step = zip(rates, rates.dropFirst()).map { $1 - $0 }.max() ?? 0
+
+        for probe in Self.bandProbes {
+            let requestedTemp = try TempBasalFunctions.setTempBasal(
+                rate: probe,
+                duration: 30,
+                profile: profile,
+                determination: createDetermination(),
+                currentTemp: createCurrentTemp()
+            )
+            let rate = try #require(requestedTemp.rate)
+
+            #expect(rate == 0 || rates.contains(rate), "\(pump) suggested \(rate) for \(probe)")
+            #expect(abs(rate - min(probe, ceiling)) <= step / 2, "\(pump) moved \(probe) to \(rate)")
+        }
     }
 }


### PR DESCRIPTION
## Summary

- round basal recommendations to the nearest supported pump rate, using half-up ties
- normalize pump-provided `Double` increments before converting them to `Decimal`
- stabilize the final `Double` passed to pump-driver floor operations so binary representation cannot lose a pump step
- apply concentration scaling to normalized pump tables
- update parity fixtures and add pump-table/concentration regression coverage

## Promotion scope

This is a sanitized fix-only promotion onto the current public `dev` baseline. It includes the complete Decimal/Double pump-delivery precision work needed for golden parity.

It deliberately excludes unrelated alpha work, including FPU behavior, performance/cache changes, Medtrum changes, storage changes, and submodule updates.

## Traceability

- base: `f7e67a20cb` (Trio synchronization PR #10)
- official Trio coverage remains attested through `8e07b51060`
- promotion commit: `c86ff5a11c`
- no submodule pointers changed

## Verification

- full `AlgorithmPackage` suite: 290 tests in 36 suites passed (performance suite skipped by design)
- focused parity/rounding suite: 39 tests in 4 suites passed
- all 28 golden-parity scenarios passed
- generated determination results were checked against the validated reference results before the golden files were updated
- `git diff --check` passed

The focused Xcode app-test invocation could not reach the test bundle in this checkout because the app scheme failed to resolve its LoopKit/device modules and encountered an unrelated iOS availability error. The independently buildable algorithm package and all affected rounding/parity tests are green.
